### PR TITLE
Fix notifications not being shown on modern Androids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ jdk:
   - oraclejdk8
 
 before_install:
-  - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28"
 
 android:
   components:
     - tools
     - platform-tools
     - extra
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
   licenses:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'

--- a/src/main/java/fr/unix_experience/owncloud_sms/engine/ASyncSMSSync.java
+++ b/src/main/java/fr/unix_experience/owncloud_sms/engine/ASyncSMSSync.java
@@ -93,12 +93,16 @@ public interface ASyncSMSSync {
 
 				if (prefs.showSyncNotifications()) {
 					OCSMSNotificationUI.notify(_context, _context.getString(R.string.sync_title),
-							_context.getString(R.string.sync_inprogress), OCSMSNotificationType.SYNC.ordinal());
+							_context.getString(R.string.sync_inprogress), OCSMSNotificationType.SYNC);
 				}
 
-				syncStartupDate = smsBuffer.getLastMessageDate();
-				performSync(smsBuffer);
-				hasSyncSomething = true;
+				try {
+					syncStartupDate = smsBuffer.getLastMessageDate();
+					performSync(smsBuffer);
+					hasSyncSomething = true;
+				} finally {
+					OCSMSNotificationUI.cancel(_context, OCSMSNotificationType.SYNC);
+				}
 			}
 		}
 
@@ -114,17 +118,16 @@ public interface ASyncSMSSync {
 					// Fetch API version first to do some early verifications
 					Log.i(ASyncSMSSync.TAG, "Server API version: " + _client.getServerAPIVersion());
 					_client.doPushRequest(smsBuffer);
-					OCSMSNotificationUI.cancel(_context);
+					OCSMSNotificationUI.cancel(_context, OCSMSNotificationType.SYNC_FAILED);
 				} catch (IllegalStateException e) { // Fail to read account data
 					OCSMSNotificationUI.notify(_context, _context.getString(R.string.fatal_error),
-							e.getMessage(), OCSMSNotificationType.SYNC_FAILED.ordinal());
+							e.getMessage(), OCSMSNotificationType.SYNC_FAILED);
 				} catch (OCSyncException e) {
 					Log.e(ASyncSMSSync.TAG, _context.getString(e.getErrorId()));
 					OCSMSNotificationUI.notify(_context, _context.getString(R.string.fatal_error),
-							e.getMessage(), OCSMSNotificationType.SYNC_FAILED.ordinal());
+							e.getMessage(), OCSMSNotificationType.SYNC_FAILED);
 				}
 			}
-			OCSMSNotificationUI.cancel(_context);
 			smsBuffer.clear();
 		}
 

--- a/src/main/java/fr/unix_experience/owncloud_sms/enums/OCSMSNotificationChannel.java
+++ b/src/main/java/fr/unix_experience/owncloud_sms/enums/OCSMSNotificationChannel.java
@@ -1,0 +1,48 @@
+package fr.unix_experience.owncloud_sms.enums;
+
+import android.app.NotificationManager;
+import android.os.Build;
+import android.support.annotation.StringRes;
+
+import fr.unix_experience.owncloud_sms.R;
+
+public enum OCSMSNotificationChannel {
+    DEFAULT("OCSMS_DEFAULT", R.string.notification_channel_name_default, null),
+    SYNC("OCSMS_SYNC", R.string.notification_channel_name_sync, null);
+
+    static {
+        // well, that's a bit of a hack :/
+        // can be inlined in the future
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            DEFAULT.importance = NotificationManager.IMPORTANCE_DEFAULT;
+            SYNC.importance = NotificationManager.IMPORTANCE_LOW;
+        }
+    }
+
+    private final String channelId;
+    private final int nameResId;
+    private final Integer descResId;
+    private int importance;
+
+    OCSMSNotificationChannel(String channelId, @StringRes int nameResId, @StringRes Integer descResId) {
+        this.channelId = channelId;
+        this.nameResId = nameResId;
+        this.descResId = descResId;
+    }
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public int getNameResId() {
+        return nameResId;
+    }
+
+    public Integer getDescResId() {
+        return descResId;
+    }
+
+    public int getImportance() {
+        return importance;
+    }
+}

--- a/src/main/java/fr/unix_experience/owncloud_sms/enums/OCSMSNotificationType.java
+++ b/src/main/java/fr/unix_experience/owncloud_sms/enums/OCSMSNotificationType.java
@@ -18,8 +18,23 @@ package fr.unix_experience.owncloud_sms.enums;
  */
 
 public enum OCSMSNotificationType {
-	SYNC,
-	SYNC_FAILED,
-	DEBUG,
-    PERMISSION,
+	SYNC(OCSMSNotificationChannel.SYNC, 0),
+	SYNC_FAILED(OCSMSNotificationChannel.DEFAULT, 1),
+    PERMISSION(OCSMSNotificationChannel.DEFAULT, 2);
+
+	private final OCSMSNotificationChannel channel;
+	private final int notificationId;
+
+	OCSMSNotificationType(OCSMSNotificationChannel channel, int notificationId) {
+		this.channel = channel;
+		this.notificationId = notificationId;
+	}
+
+	public OCSMSNotificationChannel getChannel() {
+		return channel;
+	}
+
+	public int getNotificationId() {
+		return notificationId;
+	}
 }

--- a/src/main/java/fr/unix_experience/owncloud_sms/prefs/PermissionChecker.java
+++ b/src/main/java/fr/unix_experience/owncloud_sms/prefs/PermissionChecker.java
@@ -67,7 +67,7 @@ public class PermissionChecker {
             // For context only show a notification
             OCSMSNotificationUI.notify(context, context.getString(R.string.notif_permission_required),
                     context.getString(R.string.notif_permission_required_content),
-                    OCSMSNotificationType.PERMISSION.ordinal());
+                    OCSMSNotificationType.PERMISSION);
 
             return false;
         }

--- a/src/main/java/fr/unix_experience/owncloud_sms/sync_adapters/SmsSyncAdapter.java
+++ b/src/main/java/fr/unix_experience/owncloud_sms/sync_adapters/SmsSyncAdapter.java
@@ -45,7 +45,7 @@ class SmsSyncAdapter extends AbstractThreadedSyncAdapter {
 
 		if (new OCSMSSharedPrefs(getContext()).showSyncNotifications()) {
 			OCSMSNotificationUI.notify(getContext(), getContext().getString(R.string.sync_title),
-					getContext().getString(R.string.sync_inprogress), OCSMSNotificationType.SYNC.ordinal());
+					getContext().getString(R.string.sync_inprogress), OCSMSNotificationType.SYNC);
 		}
 
 		try {
@@ -56,14 +56,13 @@ class SmsSyncAdapter extends AbstractThreadedSyncAdapter {
 
 			// and push datas
 			_client.doPushRequest(null);
-			OCSMSNotificationUI.cancel(getContext());
+			OCSMSNotificationUI.cancel(getContext(), OCSMSNotificationType.SYNC_FAILED);
 		} catch (IllegalStateException e) {
 			OCSMSNotificationUI.notify(getContext(), getContext().getString(R.string.fatal_error),
-					e.getMessage(), OCSMSNotificationType.SYNC_FAILED.ordinal());
+					e.getMessage(), OCSMSNotificationType.SYNC_FAILED);
 		} catch (OCSyncException e) {
-            OCSMSNotificationUI.cancel(getContext());
             OCSMSNotificationUI.notify(getContext(), getContext().getString(R.string.fatal_error),
-                    getContext().getString(e.getErrorId()), OCSMSNotificationType.SYNC_FAILED.ordinal());
+                    getContext().getString(e.getErrorId()), OCSMSNotificationType.SYNC_FAILED);
 			if (e.getErrorType() == OCSyncErrorType.IO) {
 				syncResult.stats.numIoExceptions++;
 			}
@@ -76,6 +75,8 @@ class SmsSyncAdapter extends AbstractThreadedSyncAdapter {
 			else {
 				Log.w(SmsSyncAdapter.TAG, "onPerformSync: unhandled response");
 			}
+		} finally {
+			OCSMSNotificationUI.cancel(getContext(), OCSMSNotificationType.SYNC);
 		}
 	}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="sync_title">Sync process</string>
     <string name="sync_inprogress">Sync in progress...</string>
     <string name="fatal_error">Fatal error ! </string>
+    <string name="notification_channel_name_default">Default</string>
+    <string name="notification_channel_name_sync">Sync</string>
 
     <!-- Errors -->
     <string name="err_sync_get_smslist">Error #1: Invalid data received from server when getting previous messages</string>


### PR DESCRIPTION
Hi!

Since `targetSdkVersion 26` notifications without a notification channel are not shown on Android 8+ ([see this](https://developer.android.com/training/notify-user/channels)).

This PR adds two notification channels: `sync` for silent sync notifications and noisy `default` for everything else.