### PR TITLE
Fix typo in french translation for value title_activity_select_account

### DIFF
--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -107,7 +107,7 @@
     <string name="choose_account">Choisissez un compte</string>
 
     <!-- Restauration -->
-    <string name="title_activity_select_account">Chosissez un compte</string>
+    <string name="title_activity_select_account">Choisissez un compte</string>
     <string name="title_activity_select_contact">Choisissez un contact</string>
     <string name="no_account_configured">Vous n\'avez pas configuré de compte.</string>
 


### PR DESCRIPTION
Hi !

First, thanks for your app !
I've downloaded it this morning and found a little typo in the french translation. So, here is the PR fixing it :)